### PR TITLE
Disable blur effect on small (mobile) devices

### DIFF
--- a/frontend/src/components/gallery/artworkCard/artworkCard.css
+++ b/frontend/src/components/gallery/artworkCard/artworkCard.css
@@ -76,3 +76,10 @@
 .artwork-card-footer > .artist {
     margin-top: 10px;
 }
+
+@media (max-width: 500px) {
+    .artwork-card-img > .effects {
+        display: none;
+        filter: none;
+    }
+}


### PR DESCRIPTION
It turns out that the blur effect in the artwork cards lags mobile devices. I'm planning to replace the blur effect with something similar on mobile devices, but the implementation I'm going for requires an additional field in the database. For now, we'll just disable the effect on mobile devices and small screens/viewports.